### PR TITLE
Replace dotall flag with cross-platform equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # wet 💧
 
-[![Build Status](https://travis-ci.org/superkonduktr/wet.svg?branch=master)](https://travis-ci.org/com.flocktory/wet)
-
 wet is a pure Clojure/ClojureScript port of the [Liquid template language](https://shopify.github.io/liquid/)
 built on top of [Instaparse](https://github.com/Engelberg/instaparse).
 
@@ -10,13 +8,13 @@ built on top of [Instaparse](https://github.com/Engelberg/instaparse).
 #### Leiningen/Boot
 
 ```
-[com.flocktory/wet "0.2.1"]
+[amperity/wet "0.2.3"]
 ```
 
 #### CLI
 
 ```clojure
-{:deps {com.flocktory/wet {:mvn/version "0.2.1"}}}
+{:deps {amperity/wet {:mvn/version "0.2.3"}}}
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flocktory/wet "0.2.2-SNAPSHOT"
+(defproject amperity/wet "0.2.3-SNAPSHOT"
   :description "Liquid in Clojure"
   :url "https://github.com/flocktory/wet"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/wet "0.2.3-SNAPSHOT"
+(defproject flocktory/wet "0.2.3-SNAPSHOT"
   :description "Liquid in Clojure"
   :url "https://github.com/flocktory/wet"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject flocktory/wet "0.2.3-SNAPSHOT"
+(defproject amperity/wet "0.2.3-SNAPSHOT"
   :description "Liquid in Clojure"
-  :url "https://github.com/flocktory/wet"
+  :url "https://github.com/amperity/wet"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]

--- a/src/wet/impl/parser/grammar.cljc
+++ b/src/wet/impl/parser/grammar.cljc
@@ -5,7 +5,7 @@
 
   template ::= (b / raw-block / object-expr-block / tag-expression)*
   <body> ::= template
-  b ::= #'(?s)((?!\\{\\{|\\{\\%).)*'
+  b ::= #'((?!\\{\\{|\\{\\%)[\\s\\S])*'
   s ::= #'[\\s\\n\\r]*'
   <ltag> ::= <'{%'> <s>
   <rtag> ::= <s> <'%}'>
@@ -16,7 +16,7 @@
   <lbrace> ::= <s> '[' <s>
   <rbrace> ::= <s> ']' <s>
 
-  raw-body ::= #'(?s)((?!\\{\\%\\s*endraw\\s*%}).)*'
+  raw-body ::= #'((?!\\{\\%\\s*endraw\\s*%})[\\s\\S])*'
   raw-block ::= ltag <'raw'> rtag raw-body ltag <'endraw'> rtag
 
   <token> ::= #'[a-zA-Z-_][a-zA-Z0-9-_]*'

--- a/src/wet/impl/utils.cljc
+++ b/src/wet/impl/utils.cljc
@@ -1,7 +1,7 @@
 (ns wet.impl.utils
   #?(:clj (:import (java.util Date))))
 
-#?(:cljs (defn- non-NaN [v] (when-not (js/isNaN v) v)))
+#?(:cljs (defn- non-NaN [^number v] (when-not ^boolean (js/isNaN v) v)))
 
 (defn safe-long
   [v]


### PR DESCRIPTION
The `s` regex flag [isn't compatible](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll#Browser_compatibility) with Firefox, Edge, and IE, which causes the grammar creation to fail. This PR removes the `s` flag and replaces dots in regexes that use it with `[\s\S]`.